### PR TITLE
Add a page to link the Toolchain documentation

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -23,6 +23,7 @@ CoreSense Project (CoreSense in short) is a project... TBD
    tutorials/index.rst
    testbeds/index.rst
    demos/index.rst
+   toolchain/index.rst
    about/index.rst
 
    

--- a/toolchain/index.rst
+++ b/toolchain/index.rst
@@ -1,0 +1,26 @@
+.. _toolchain_introduction:
+
+CoreSense Toolchain
+***********************
+
+CORESENSE is revolutionizing the way cognitive architectures are developed. By introducing groundbreaking concepts and leveraging model-based technologies, we are improving the creation of cognitive components and systems. Recognizing the challenges new users face, we are dedicated to creating a user-friendly toolchain that makes our innovative solutions accessible and easy to implement. 
+
+Designed to automate and enhance the software development process, our toolchain aims to: 
+
+- Automate repetitive tasks, reducing manual effort, saving time, and minimizing errors.
+
+- Enforce consistency and standardization across the development lifecycle.
+
+- Promote collaboration, facilitate knowledge sharing, and improve overall software quality.
+
+- Lower the entry barrier for designing and implementing complex autonomous robot systems through intuitive, user-friendly interfaces. 
+
+Our toolchain allows users to conceptualize and structurally design solutions, handling the implementation seamlessly.  By integrating a comprehensive set of tools and workflows, it manages tedious and repetitive tasks, freeing software experts to tackle more challenging aspects of development. We aim to create a toolchain that resonates with the ROS user community, adhering to their needs. Our goal is to make it ROS-user-friendly, ensuring it is well-received and widely adopted. 
+
+Discover how CORESENSE is transforming the future of robotics with our innovative, user-centric toolchain! 
+
+The CoreSense toolchain is composed of several modules. In its first release, the main module is an IDE based on Eclipse for editing and composing components and system models for ROS. This solution tool is an updated version of the existing RosTooling. This tooling has as a backend a set of metamodels to represent ROS concepts and properties. From the metamodels, we have created different DSLs whose compiler allows both, model validation and code generation. In addition, it provides tools for visualization of the models that serve for debugging the system as well as for documentation.
+
+The source code is available under: `GitHub <https://github.com/ipa320/RosTooling>`_.
+
+We also invite you to take a look to the `tutorials <https://ipa320.github.io/RosTooling.github.io/>`_ site.


### PR DESCRIPTION
I have added a new page to hold information about the Toolchain.
For now, it just includes links to the current documentation. The plan is to migrate here the content for future workshops and dissemination activities. 